### PR TITLE
chore: enable FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build and Release


### PR DESCRIPTION
## Summary

This PR adds the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable to all GitHub Actions workflow files in this repository.

## What this does

Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as a workflow-level environment variable instructs GitHub Actions to run all JavaScript-based actions using the Node.js 24 runtime instead of the default version.

## Why

GitHub is transitioning Actions to Node.js 24. This environment variable opts in early, ensuring compatibility and allowing us to catch any issues before the mandatory migration.

## Changes

- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the top-level `env:` block of every workflow file in `.github/workflows/`
- No action versions were modified
