### PR TITLE
Add .deb package generation for Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,27 +35,27 @@ jobs:
           - { displayName: 32-bit Linux,
               rustTarget: i686-unknown-linux-gnu,
               debArch: i386,
-              runner: 'ubuntu-latest' }
+              runner: 'ubuntu-22.04' }
 
           - { displayName: 64-bit Linux,
               rustTarget: x86_64-unknown-linux-gnu,
               debArch: amd64,
-              runner: 'ubuntu-latest' }
+              runner: 'ubuntu-22.04' }
 
           - { displayName: ARM32 ARMv6 Linux,
               rustTarget: arm-unknown-linux-gnueabi,
               debArch: armel,
-              runner: 'ubuntu-latest' }
+              runner: 'ubuntu-22.04' }
 
           - { displayName: ARM32 ARMv7 Linux,
               rustTarget: armv7-unknown-linux-gnueabihf,
               debArch: armhf,
-              runner: 'ubuntu-latest' }
+              runner: 'ubuntu-22.04' }
 
           - { displayName: ARM64 Linux,
               rustTarget: aarch64-unknown-linux-gnu,
               debArch: arm64,
-              runner: 'ubuntu-latest' }
+              runner: 'ubuntu-22.04' }
 
           # macOS
           - { displayName: 64-bit macOS,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,9 @@ jobs:
       - name: Build .deb package
         if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
         run: |
-          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
-          cp ./target/${{ matrix.target.rustTarget }}/release/httpbandwidthspeedtester dpkg/usr/local/bin/
-          chmod 755 dpkg/usr/local/bin/httpbandwidthspeedtester
+          mkdir -p dpkg/DEBIAN dpkg/usr/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/httpbandwidthspeedtester dpkg/usr/bin/
+          chmod 755 dpkg/usr/bin/httpbandwidthspeedtester
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           cat > dpkg/DEBIAN/control << EOF
@@ -137,4 +137,4 @@ jobs:
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
-          gh release upload ${{ github.event.release.tag_name }} ./httpbandwidthspeedtester_${VERSION}_${{ matrix.target.debArch }}.deb
+          gh release upload ${{ github.event.release.tag_name }} --clobber ./httpbandwidthspeedtester_${VERSION}_${{ matrix.target.debArch }}.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,22 +34,27 @@ jobs:
           # Linux
           - { displayName: 32-bit Linux,
               rustTarget: i686-unknown-linux-gnu,
+              debArch: i386,
               runner: 'ubuntu-latest' }
 
           - { displayName: 64-bit Linux,
               rustTarget: x86_64-unknown-linux-gnu,
+              debArch: amd64,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM32 ARMv6 Linux,
               rustTarget: arm-unknown-linux-gnueabi,
+              debArch: armel,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM32 ARMv7 Linux,
               rustTarget: armv7-unknown-linux-gnueabihf,
+              debArch: armhf,
               runner: 'ubuntu-latest' }
 
           - { displayName: ARM64 Linux,
               rustTarget: aarch64-unknown-linux-gnu,
+              debArch: arm64,
               runner: 'ubuntu-latest' }
 
           # macOS
@@ -106,3 +111,30 @@ jobs:
         run:
           cp ./target/${{ matrix.target.rustTarget }}/release/httpbandwidthspeedtester${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} ./httpbandwidthspeedtester-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} &&
           gh release upload ${{ github.event.release.tag_name }} ./httpbandwidthspeedtester-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }}#"httpbandwidthspeedtester-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} (${{ matrix.target.displayName }})"
+
+      - name: Build .deb package
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        run: |
+          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/httpbandwidthspeedtester dpkg/usr/local/bin/
+          chmod 755 dpkg/usr/local/bin/httpbandwidthspeedtester
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          cat > dpkg/DEBIAN/control << EOF
+          Package: httpbandwidthspeedtester
+          Version: $VERSION
+          Architecture: ${{ matrix.target.debArch }}
+          Maintainer: richardsondev
+          Description: HTTP bandwidth speed testing tool
+          EOF
+          sed -i 's/^          //' dpkg/DEBIAN/control
+          dpkg-deb --build dpkg httpbandwidthspeedtester_${VERSION}_${{ matrix.target.debArch }}.deb
+
+      - name: Upload .deb Release Asset
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          gh release upload ${{ github.event.release.tag_name }} ./httpbandwidthspeedtester_${VERSION}_${{ matrix.target.debArch }}.deb


### PR DESCRIPTION
## Summary

Adds `.deb` package generation to the release workflow for all Linux architectures. Uses `ubuntu-22.04` runners for Linux builds to ensure glibc compatibility with Debian bookworm.

## Changes

- Added `debArch` field to each Linux target in the build matrix (`i386`, `amd64`, `armel`, `armhf`, `arm64`)
- Added a `Build .deb package` step that uses `dpkg-deb` to create Debian packages after the binary is compiled
- Added `Upload .deb Release Asset` step with `--clobber` for idempotent re-runs
- Changed Linux build runners from `ubuntu-latest` to `ubuntu-22.04` for glibc 2.35 compatibility (Debian bookworm ships glibc 2.36)
- Binary installs to `/usr/bin/httpbandwidthspeedtester`

## How it works

On a `release` event, each Linux matrix job creates a `.deb` package using `dpkg-deb --build`. The package contains the binary at `/usr/bin/httpbandwidthspeedtester` and a `DEBIAN/control` file with package name, version (from the release tag), and architecture. The `.deb` is uploaded to the GitHub Release alongside existing raw binaries.

## Architectures

| Debian Arch | Rust Target |
|---|---|
| `amd64` | `x86_64-unknown-linux-gnu` |
| `i386` | `i686-unknown-linux-gnu` |
| `arm64` | `aarch64-unknown-linux-gnu` |
| `armhf` | `armv7-unknown-linux-gnueabihf` |
| `armel` | `arm-unknown-linux-gnueabi` |

## Usage

```bash
sudo dpkg -i httpbandwidthspeedtester_0.05_amd64.deb
httpbandwidthspeedtester http://example.com/testfile
```
