### PR TITLE
chore: add SPDX-License-Identifier header to main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 use bytes::Bytes;
 use chrono::Local;
 use futures_util::StreamExt;


### PR DESCRIPTION
Adds `// SPDX-License-Identifier: MIT` at the top of `src/main.rs` so the
license is discoverable from every source file (matching the existing
`LICENSE` file). No-op at runtime; one-line change.

Part of an audit-fix fleet — finding **H3** of the recent code review.
