### PR TITLE
docs: declare accurate MSRV in Cargo.toml and README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "httpbandwidthspeedtester"
 version = "0.1.0"
 authors = ["richardsondev"]
 edition = "2021"
+rust-version = "1.74"
 
 [dependencies]
 hyper = { version = "1.6", features = ["client", "http1", "http2"] }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This application is a very simple bandwidth testing tool written in Rust. It is 
 
 To run this application, you will need:
 
-- Rust 1.41.0 or later
+- Rust 1.74.0 or later (as declared by `rust-version` in `Cargo.toml`)
 - Cargo (usually comes with Rust)
 
 ## How to Use


### PR DESCRIPTION
The README currently claims "Rust 1.41.0 or later". The codebase uses
`edition = "2021"` (requires 1.56) and pulls in `hyper 1.x` + `tokio 1.x`,
whose effective MSRV is around **1.74**.

This PR:

- Declares `rust-version = "1.74"` in `Cargo.toml` (verified by `cargo`
  edition compatibility and dependency MSRV requirements).
- Updates the `Build Requirements` section of the README to match.

Part of an audit-fix fleet — finding **D1** of the recent code review.
