### PR TITLE
build: tune release profile (lto, codegen-units, strip, panic=abort)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,9 @@ chrono = "0.4"
 tokio-native-tls = "0.3"
 futures-util = "0.3"
 openssl = { version = "0.10.79", features = ["vendored"] }
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = true
+panic = "abort"


### PR DESCRIPTION
Adds a tuned `[profile.release]` to `Cargo.toml`:

```toml
[profile.release]
lto = "fat"
codegen-units = 1
strip = true
panic = "abort"
```

This shrinks the binary substantially (full LTO + single codegen unit + symbol
stripping + abort-on-panic instead of unwinding) and lets LLVM inline more
aggressively across crate boundaries.

Trade-off: link time goes up a few seconds for release builds. CI already
strips post-build; this just bakes the same plus more into the profile.

Part of an audit-fix fleet — finding **P2** of the recent code review.
