### PR TITLE
build: trim tokio features from full to the subset actually used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ hyper = { version = "1.6", features = ["client", "http1", "http2"] }
 hyper-tls = "0.6"
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "tokio"] }
 http-body-util = "0.1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net"] }
 num_cpus = "1.17.0"
 bytes = "1.11"
 tokio-util = { version = "0.7", features = ["codec"] }


### PR DESCRIPTION
`tokio` is currently pulled in with `features = ["full"]`, which enables every
optional component (process, signal, fs, io-util, io-std, parking_lot, etc.)
even though the binary only uses the multi-threaded runtime, the `#[main]`
macro, timers, and the async mutex.

This PR trims the feature list to:

```toml
tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net"] }
```

Result: faster compiles and a smaller release binary, no behaviour change.

Part of an audit-fix fleet — finding **P3** of the recent code review.
