### PR TITLE
refactor: replace num_cpus with std::thread::available_parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ hyper-tls = "0.6"
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "tokio"] }
 http-body-util = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net"] }
-num_cpus = "1.17.0"
 bytes = "1.11"
 tokio-util = { version = "0.7", features = ["codec"] }
 chrono = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use hyper_util::rt::TokioExecutor;
 use std::cmp::max;
 use std::collections::VecDeque;
 use std::error::Error;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
@@ -150,7 +151,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         });
 
     // Calculate the number of bytes to download in each thread
-    let num_cpus: u64 = num_cpus::get() as u64;
+    let num_cpus: u64 = std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1) as u64;
     let bytes_per_cpu: u64 = content_length / num_cpus;
 
     // Create the shared download state


### PR DESCRIPTION
`num_cpus::get()` predates `std::thread::available_parallelism`, which was
stabilised in Rust 1.59 and returns a `NonZeroUsize` reading the same
underlying APIs (sched_getaffinity on Linux, `GetActiveProcessorCount` on
Windows, etc.).

This PR:

- Replaces `num_cpus::get() as u64` with `std::thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1) as u64`.
- Drops the `num_cpus` dependency from `Cargo.toml`.

One fewer external crate, identical semantics. The fallback of `1` matches
`num_cpus::get()`'s documented "always returns at least 1" guarantee.

Part of an audit-fix fleet — finding **P4** of the recent code review.
