### PR TITLE
fix: initialise speed-bucket clock once instead of per worker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -78,11 +78,6 @@ async fn start_download(
     let body = res.into_body();
     let mut body_stream = BodyStream::new(body);
 
-    // Set the start time
-    let mut state: tokio::sync::MutexGuard<'_, DownloadState> = download_state.lock().await;
-    state.last_second = Instant::now();
-    drop(state);
-
     // Process each chunk of data as it arrives
     while let Some(frame_result) = body_stream.next().await {
         let frame = frame_result?;


### PR DESCRIPTION
Every spawned worker currently runs:

```rust
let mut state: tokio::sync::MutexGuard<'_, DownloadState> = download_state.lock().await;
state.last_second = Instant::now();
drop(state);
```

…before its first chunk arrives. With N workers starting in parallel,
whichever wins the lock last defines the timer, so the first reported speed
bucket is distorted (over- or under-counted depending on order).

`DownloadState::last_second` is already initialised to `Instant::now()` in
`main` when the struct is constructed, so this per-worker reset is both
racey and redundant.

This PR deletes the redundant reset; no other behaviour changes.

Part of an audit-fix fleet — finding **B4** of the recent code review.
