### PR TITLE
fix: fail fast on non-2xx HTTP responses instead of counting error-page bytes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .uri(url.clone())
         .body(Empty::<Bytes>::new())?;
     let res = client.request(req).await?;
+    if !res.status().is_success() {
+        return Err(format!("Server returned HTTP {}", res.status()).into());
+    }
     let headers = res.headers();
     let content_length: u64 = headers
         .get(CONTENT_LENGTH)


### PR DESCRIPTION
The tool currently never checks the HTTP status returned by the initial probe.
A `404 Not Found` from the server is silently treated as a successful download
of the error page — observed empirically: a `GET http://nginx/does-not-exist`
returns `Download completed: 3672 bytes downloaded` with exit code 0.

This PR rejects the request up front when the probe response is not
`2xx Success`, prints the status, and exits non-zero so calling scripts can
detect the failure.

Part of an audit-fix fleet — finding **B2** of the recent code review.
