### PR TITLE
fix: compute final speed from total bytes / elapsed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Start the print loop
     let print_handle = tokio::spawn(print_loop(download_state.clone()));
+    let start_time = Instant::now();
 
     // Start the downloads
     let mut handles: Vec<tokio::task::JoinHandle<Result<(), Box<dyn Error + Send + Sync>>>> =
@@ -193,8 +194,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Print out the total bytes downloaded and the average speed
     let state: tokio::sync::MutexGuard<'_, DownloadState> = download_state.lock().await;
-    let total_past_bytes: u64 = state.past_seconds.iter().sum();
-    let avg_speed: u64 = total_past_bytes / max(state.past_seconds.len() as u64, 1);
+    let elapsed_secs = start_time.elapsed().as_secs_f64().max(1e-9);
+    let avg_speed: u64 = (state.total_bytes_downloaded as f64 / elapsed_secs) as u64;
     let avg_speed_kb: u64 = avg_speed / 1024;
     let avg_speed_mb: u64 = avg_speed / (1024 * 1024);
     println!(


### PR DESCRIPTION
The final summary currently averages only the *completed* one-second buckets
in `past_seconds`. If the whole download took less than one second, no
bucket is ever pushed and the final line reports `0 B/s` — empirically
verified for a 1 MiB and 64 MiB localhost download.

This PR records a `start_time = Instant::now()` immediately before the
parallel downloads spawn, and at completion reports

```text
avg = total_bytes_downloaded / elapsed.as_secs_f64()
```

The per-second `past_seconds` buffer is still used by the print loop during
the download itself; it just no longer dictates the final summary.

Part of an audit-fix fleet — finding **B6** of the recent code review.
