### PR TITLE
ci: build aarch64-apple-darwin release binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,10 @@ jobs:
               rustTarget: x86_64-apple-darwin,
               runner: 'macos-latest' }
 
+          - { displayName: 64-bit macOS (Apple Silicon),
+              rustTarget: aarch64-apple-darwin,
+              runner: 'macos-latest' }
+
     runs-on: ${{ matrix.target.runner }}
     steps:
       # Get the machine ready to build
@@ -91,7 +95,7 @@ jobs:
         run: sudo apt-get install -y gcc-arm-linux-gnueabihf gcc-arm-linux-gnueabi gcc-arm-none-eabi binutils-arm-linux-gnueabi
 
       - name: Add ARM64 Build Dependencies
-        if: ${{ contains(matrix.target.rustTarget, 'aarch64') }}
+        if: ${{ contains(matrix.target.rustTarget, 'aarch64-unknown-linux') }}
         run: sudo apt-get install -y gcc-aarch64-linux-gnu crossbuild-essential-arm64
 
       - name: Add 32-bit Linux Build Dependencies


### PR DESCRIPTION
The release matrix builds `x86_64-apple-darwin` but not `aarch64-apple-darwin`.
As of November 2024, GitHub's `macos-latest` runner is Apple Silicon, and the
vast majority of new macOS hardware is M-series. Users on Apple Silicon
currently have to either install Rosetta or build from source.

This PR adds an `aarch64-apple-darwin` row to the build matrix. The runner
is left as `macos-latest` (now arm64-native), so the build is fully native
with no cross-compile setup needed.

Part of an audit-fix fleet — finding **C4** of the recent code review.
