### PR TITLE
ci: pin GitHub Actions by commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       # Get the machine ready to build
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -107,7 +107,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target.rustTarget }}
 
       - name: Upload Asset
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: httpbandwidthspeedtester-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }}
           path: ./target/${{ matrix.target.rustTarget }}/release/httpbandwidthspeedtester${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }}


### PR DESCRIPTION
Pins every third-party GitHub Action by commit SHA, with a trailing comment
giving the tag for human readability:

| Action                         | Tag | SHA (pinned)                            |
|--------------------------------|-----|-----------------------------------------|
| `actions/checkout`             | v6  | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/upload-artifact`      | v7  | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |

Pinning by SHA defends against supply-chain attacks that retag a release
maliciously. Dependabot recognises this pattern and bumps both the SHA and
the trailing comment when a new version is published.

Part of an audit-fix fleet — finding **C5** of the recent code review.
