### PR TITLE
ci: default workflow GITHUB_TOKEN to read-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Release


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` so jobs that don't explicitly
opt into `contents: write` cannot mutate the repo. The existing release-upload
steps continue to declare `permissions: contents: write` at the job level so
nothing observable changes for the happy path; this just removes implicit
write access from any future job that gets added to this workflow without
thinking about permissions.

Aligns the repo with GitHub's
[hardening recommendations](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).

Part of an audit-fix fleet — finding **C6** of the recent code review.
