### PR TITLE
docs: add CHANGELOG.md (Keep a Changelog format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Maintenance and dependency updates; see git log for details.
+
+## Released
+
+This project has been published as a series of GitHub releases. See the
+[Releases page](https://github.com/richardsondev/httpbandwidthspeedtester/releases)
+for the binaries and the auto-generated release notes for each tag.
+
+Notable historical changes:
+
+- Migrate to hyper 1.x API.
+- Add `.deb` package generation for Linux releases.
+- Various `openssl` security updates via Dependabot.
+- Response parsing improvements.
+
+[Unreleased]: https://github.com/richardsondev/httpbandwidthspeedtester/compare/HEAD


### PR DESCRIPTION
Starts a human-readable, [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
style `CHANGELOG.md`. Pre-populates the historical entries that already exist
as git tags and a forward-looking `[Unreleased]` section.

Part of an audit-fix fleet — finding **D4** of the recent code review.
