### PR TITLE
ci: add cargo audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,39 @@
+name: Audit
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/audit.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/audit.yml"
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: cargo audit
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings


### PR DESCRIPTION
Adds a weekly + on-PR `cargo audit` workflow that flags known-vulnerable
dependencies via the [RustSec advisory database](https://rustsec.org/).
This is non-optional for this codebase because `openssl` is built with
`features = ["vendored"]`, so vulnerable OpenSSL versions ship inside the
release binary — Dependabot won't catch a `RUSTSEC` advisory on its own.

The job runs:

- on every PR touching `Cargo.lock` / `Cargo.toml`,
- on every push to `master`,
- on a weekly schedule so we hear about new advisories without waiting for
  another commit.

Part of an audit-fix fleet — finding **C2** of the recent code review.
