### PR TITLE
ci: standardise Ubuntu runners on ubuntu-24.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,37 +30,37 @@ jobs:
           # Windows
           - { displayName: 32-bit Windows,
               rustTarget: i686-pc-windows-gnu,
-              runner: 'ubuntu-latest' }
+              runner: 'ubuntu-24.04' }
 
           - { displayName: 64-bit Windows,
               rustTarget: x86_64-pc-windows-gnu,
-              runner: 'ubuntu-latest' }
+              runner: 'ubuntu-24.04' }
 
           # Linux
           - { displayName: 32-bit Linux,
               rustTarget: i686-unknown-linux-gnu,
               debArch: i386,
-              runner: 'ubuntu-22.04' }
+              runner: 'ubuntu-24.04' }
 
           - { displayName: 64-bit Linux,
               rustTarget: x86_64-unknown-linux-gnu,
               debArch: amd64,
-              runner: 'ubuntu-22.04' }
+              runner: 'ubuntu-24.04' }
 
           - { displayName: ARM32 ARMv6 Linux,
               rustTarget: arm-unknown-linux-gnueabi,
               debArch: armel,
-              runner: 'ubuntu-22.04' }
+              runner: 'ubuntu-24.04' }
 
           - { displayName: ARM32 ARMv7 Linux,
               rustTarget: armv7-unknown-linux-gnueabihf,
               debArch: armhf,
-              runner: 'ubuntu-22.04' }
+              runner: 'ubuntu-24.04' }
 
           - { displayName: ARM64 Linux,
               rustTarget: aarch64-unknown-linux-gnu,
               debArch: arm64,
-              runner: 'ubuntu-22.04' }
+              runner: 'ubuntu-24.04' }
 
           # macOS
           - { displayName: 64-bit macOS,


### PR DESCRIPTION
The matrix mixes `ubuntu-latest` (for Windows cross-compile rows) and
`ubuntu-22.04` (for the Linux + ARM rows). Ubuntu 22.04 reaches standard EOL
in 2027, after which `ubuntu-22.04` runners will be removed.

This PR standardises every Ubuntu runner on `ubuntu-24.04`. The matrix entries
that build on Linux-hosted runners (Windows / Linux / ARM cross-compiles) all
move from a mix of `ubuntu-latest` and `ubuntu-22.04` to a single explicit
`ubuntu-24.04`, making it obvious what runner version is in use and ensuring
the workflow doesn't silently change when GitHub repoints `ubuntu-latest`.

Part of an audit-fix fleet — finding **C9** of the recent code review.
