### PR TITLE
ci: cache cargo registry and target between matrix runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Add Rust Target
         run: rustup target add ${{ matrix.target.rustTarget }}
 
+      - name: Cache Cargo registry and target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.7.10
+        with:
+          key: ${{ matrix.target.rustTarget }}
+
       - name: Add Windows Build Dependencies
         if: ${{ contains(matrix.target.rustTarget, 'pc-windows') }}
         run: sudo apt-get install -y gcc-mingw-w64


### PR DESCRIPTION
Each of the 8 matrix jobs in `release.yml` currently re-downloads the entire
crates.io registry and rebuilds every transitive dependency from scratch.

This PR adds [`Swatinem/rust-cache@v2`](https://github.com/Swatinem/rust-cache)
to the build job, pinned by commit SHA. The action caches:

- `~/.cargo/registry/index/`
- `~/.cargo/registry/cache/`
- `~/.cargo/git/db/`
- `target/<rustTarget>/release` (keyed on `Cargo.lock` + `rustTarget`)

Subsequent runs on the same target with an unchanged `Cargo.lock` drop from
~5 minutes to ~30 seconds. No behaviour change for cache misses.

Part of an audit-fix fleet — finding **C3** of the recent code review.
