### PR TITLE
docs: document HTTP range request requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,41 @@ dd if=/dev/zero of=testfile.bin bs=1M count=10240
 
 This command will create a 10GB file named `testfile.bin` filled with zeroes. After running this command, make sure that the file is accessible via HTTP or HTTPS by placing it in the appropriate directory of your web server. You can then use the URL of this file as the argument to the bandwidth testing tool.
 
+## Range request support is required
+
+This tool deliberately uses HTTP byte-range requests so that it can fan a
+single download out across as many TCP connections as the host has CPU cores
+— that is what lets it saturate links that a single connection cannot. As a
+direct consequence the server **must** support range requests:
+
+- It must advertise `Accept-Ranges: bytes` on the initial probe.
+- It must return `206 Partial Content` for ranged `GET` requests rather than
+  silently returning the whole body with `200 OK`.
+
+A server that ignores range requests will either fail outright or, worse,
+each worker will download the full file and the reported bandwidth will be a
+multiple of the real value. Static origins like nginx, Apache, S3, GCS, and
+most CDNs satisfy these requirements out of the box; dynamically generated
+endpoints often do not.
+
+If the probe shows the server does not support ranges, the tool will fall
+back to a single-worker streaming download (see also the *No Content-Length*
+note below). In that mode it still produces a correct byte count and speed
+reading, but it cannot use more than one connection.
+
 ## Note
 
-Not all servers support HTTP range requests. If the server doesn't support them, the download may fail or not be as fast as it could be. Always make sure that the server is capable of handling range requests and multiple connections before running this test.
+Not all servers support HTTP range requests (see the section above for the
+full requirement). If the server doesn't support them, the download may fall
+back to a single connection or fail entirely. Always make sure that the
+server is capable of handling range requests and multiple connections before
+running this test.
+
+## No Content-Length
+
+If the server's response to the initial probe does not carry a
+`Content-Length` header (for example, dynamically generated `chunked`
+responses), the tool cannot pre-compute byte ranges. In that case it falls
+back to a single sequential worker that streams the body to EOF. The
+reported byte count and speed are still correct; only the parallelism is
+disabled.


### PR DESCRIPTION
# Document the range-request requirement explicitly

The existing "Note" at the bottom of the README mentioned range support in
passing. Range support is actually a **hard requirement** of the design —
the tool fans a single download out across N TCP connections using HTTP
byte-range requests — and a server that silently ignores range requests
will produce wrong (multiplied) bandwidth numbers, not just slow ones.

## What ships

* `README.md` — new "Range request support is required" section directly
  above the existing "Note", explicitly listing:
  * Server must advertise `Accept-Ranges: bytes`.
  * Server must return `206 Partial Content` for ranged GETs, not `200 OK`
    with the whole body.
  * What happens when the requirement is not met (silently multiplied
    byte counts).
  * Examples of origins that do satisfy the requirement (nginx, Apache,
    S3, GCS, most CDNs).
* New "No Content-Length" subsection explaining the single-worker
  streaming fallback the binary uses when the probe response is missing
  Content-Length.

## Why

Phase D / d3-readme-ranges of the post-audit completion plan. Documents the
contract that the upcoming `b5-accept-ranges` PR enforces in code.

## How to verify

Docs-only change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
