### PR TITLE
docs: record TLS-stack decision (vendored OpenSSL, rustls deferred)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Maintenance and dependency updates; see git log for details.
 
+### Decisions
+
+- **TLS implementation: continues to use OpenSSL (vendored).** The post-audit
+  review evaluated migrating to `rustls` to remove the OpenSSL build-time
+  dependency. That migration was intentionally deferred: vendoring OpenSSL
+  keeps the released binary completely free of system runtime dependencies
+  (no `libssl.so.X` requirement), which is the project's explicit deployment
+  contract. `cargo audit` and Dependabot remain the controls for the
+  vendored copy. Re-evaluate if OpenSSL becomes harder to cross-build or if
+  a critical advisory ships without a same-day OpenSSL patch.
+
 ## Released
 
 This project has been published as a series of GitHub releases. See the


### PR DESCRIPTION
# Record the rustls migration decision (deferred)

Closes out the `p5-rustls` audit finding by documenting the deliberate
decision to keep TLS on vendored OpenSSL rather than migrating to `rustls`.

## What ships

* `CHANGELOG.md` — new `### Decisions` subsection under `[Unreleased]`
  explaining:
  * Vendored OpenSSL is the deployment contract — it produces a binary with
    zero system runtime dependencies (no `libssl.so.X` required).
  * The audit finding was evaluated and intentionally deferred.
  * The mitigating controls (`cargo audit`, Dependabot) for the vendored
    copy remain in place.
  * The conditions under which the decision should be re-evaluated.

## Why

Phase E of the post-audit completion plan. `p5-rustls` is the only audit
finding marked **cancelled** rather than complete; this PR is the durable,
public record of why, so future contributors don't have to re-litigate the
choice from scratch.

## How to verify

Docs-only change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
