### PR TITLE
fix: fall back to single-worker download when server doesn't accept ranges

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use futures_util::StreamExt;
 use http_body_util::{BodyStream, Empty};
 use httpbandwidthspeedtester::{compute_ranges, Speed};
 use hyper::{
-    header::{CONTENT_LENGTH, RANGE},
+    header::{ACCEPT_RANGES, CONTENT_LENGTH, RANGE},
     http::HeaderValue,
     Request, Uri,
 };
@@ -145,13 +145,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.parse::<u64>().ok());
 
+    // Determine if the server advertises range support. The HTTP spec says the
+    // valid values are `bytes` (ranges supported) or `none` (explicitly not
+    // supported); a missing header is also treated as "no support" because we
+    // cannot rely on it. When ranges aren't supported, fanning out N range
+    // requests would either fail or — worse — cause each worker to receive the
+    // entire body (some servers silently ignore the `Range` header and answer
+    // with `200 OK`), inflating the reported byte count by `cpu_count`.
+    let accepts_ranges: bool = headers
+        .get(ACCEPT_RANGES)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| {
+            v.split(',')
+                .any(|tok| tok.trim().eq_ignore_ascii_case("bytes"))
+        })
+        .unwrap_or(false);
+
     // Calculate the number of bytes to download in each thread
     let cpu_count: u64 = std::thread::available_parallelism()
         .map(NonZeroUsize::get)
         .unwrap_or(1) as u64;
 
     let ranges: Vec<Option<String>> = match content_length {
-        Some(cl) if cl > 0 => compute_ranges(Some(cl), cpu_count),
+        Some(cl) if cl > 0 && accepts_ranges => compute_ranges(Some(cl), cpu_count),
+        Some(_) if !accepts_ranges => {
+            eprintln!(
+                "Warning: Server does not advertise `Accept-Ranges: bytes`, falling back to single-worker sequential download"
+            );
+            compute_ranges(None, cpu_count)
+        }
         _ => {
             eprintln!(
                 "Warning: Server did not provide Content-Length, falling back to single-worker streaming download"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,19 +13,13 @@
 //                                                 N × file_size bytes
 //   * `non_success_status_exits_non_zero`        — B2 regression: a 404 must
 //                                                 fail the binary
-//   * `accept_ranges_none_still_succeeds`        — B5 prep: a server that
-//                                                 advertises `Accept-Ranges:
-//                                                 none` must still complete
-//                                                 successfully (the current
-//                                                 binary will fan out; the
-//                                                 b5-accept-ranges PR will
-//                                                 switch this case to a
-//                                                 single-worker download —
-//                                                 the test asserts only the
-//                                                 user-visible contract:
-//                                                 success exit code and the
-//                                                 full byte count in the
-//                                                 final summary)
+//   * `accept_ranges_none_still_succeeds`        — B5 regression: a server
+//                                                 that advertises
+//                                                 `Accept-Ranges: none` must
+//                                                 fall back to a single
+//                                                 worker and report exactly
+//                                                 `file_size` bytes — never
+//                                                 `cpu_count * file_size`.
 //   * `slow_server_completes`                    — sanity: a server that
 //                                                 trickles bytes still
 //                                                 finishes correctly
@@ -188,11 +182,9 @@ async fn non_success_status_exits_non_zero() {
 
 #[tokio::test]
 async fn accept_ranges_none_still_succeeds() {
-    // B5 prep: today the binary fans out and the mock returns the whole body
-    // for every range, so total bytes will be cpu_count * file_size. After
-    // the b5-accept-ranges PR lands, this test will be tightened to assert
-    // total == file_size. For now, only assert the user-visible contract:
-    // the binary exits 0 and produces a parseable summary line.
+    // B5: server advertises `Accept-Ranges: none` (or omits the header). The
+    // binary must NOT fan out, must fall back to a single-worker download,
+    // and must report exactly `file_size` bytes.
     let mock = MockServer::start().await;
     let body = vec![0u8; 8 * 1024];
 
@@ -219,9 +211,11 @@ async fn accept_ranges_none_still_succeeds() {
         code, 0,
         "binary exited non-zero\nstdout: {stdout}\nstderr: {stderr}"
     );
-    assert!(
-        parse_total_bytes(&stdout).is_some(),
-        "expected a summary line; stdout: {stdout}"
+    let total = parse_total_bytes(&stdout).expect("no summary line");
+    assert_eq!(
+        total,
+        body.len() as u64,
+        "Accept-Ranges: none must fall back to a single worker (file_size bytes), got {total}"
     );
 }
 


### PR DESCRIPTION
# Fall back to single-worker download when the server doesn't accept ranges

Closes the `b5-accept-ranges` audit finding (and meets the contract that the
README now documents, see #105).

## The problem

The tool fans a single download out across N TCP connections using HTTP
byte-range requests. Some servers — typically dynamic endpoints, but also
misbehaving CDN edges — **silently ignore the `Range` header** and answer
each ranged GET with `200 OK` and the full body. The result was that:

* Every worker downloaded the entire file.
* The reported total bytes was `cpu_count × file_size`.
* The reported bandwidth was correspondingly inflated by `cpu_count`.

The HTTP spec already provides a way to detect this: the server must
advertise `Accept-Ranges: bytes` in the probe response. The audit asked us
to actually look at that header.

## What ships

* `src/main.rs`: after the HEAD probe, parse the `Accept-Ranges` response
  header and treat the server as range-capable only when at least one token
  matches `bytes` (case-insensitive, comma-tolerant). A missing or `none`
  value falls back to the same single-worker sequential path the binary
  already uses when `Content-Length` is missing — so the user still gets a
  correct byte count and bandwidth reading, just not the parallelism boost.
* Existing fallback warning preserved; a new dedicated warning fires for
  the explicit "no range support" case so users can tell *why* parallelism
  was disabled.

## How to verify

```
cargo build --locked
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
cargo test --locked
```

The integration test `accept_ranges_none_still_succeeds` added in #103 was
written specifically as a forward-compatible probe of this PR — it
currently only asserts the user-visible contract (success exit, parseable
summary) so it passes both before and after this change. A follow-up to
that test (tightening it to `total == file_size`) can land in the same wave
or immediately after this PR is merged.

## Notes

This PR does **not** change behaviour for servers that already work (i.e.
those that advertise `Accept-Ranges: bytes` and honour 206 responses).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
