### PR TITLE
build: pin Rust toolchain to 1.85.0 via rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Pin a stable Rust toolchain so every contributor and CI runner uses
+# the same compiler. Bumped via PR alongside any MSRV bump in
+# Cargo.toml.
+[toolchain]
+channel    = "1.85.0"
+components = ["rustfmt", "clippy"]
+profile    = "minimal"


### PR DESCRIPTION
## Summary
Pin the Rust toolchain to stable **1.85.0** via `rust-toolchain.toml`.

## Why
Every contributor and CI runner now compiles with the same Rust
version, eliminating "works on my machine" diffs caused by rolling
stable. Bumped alongside any MSRV bump in `Cargo.toml`.

## Validation
- `cargo --version` resolves to 1.85.0 inside the worktree.
- CI matrix (8 build targets + lint + test + audit) must remain green.

Part of the Rust best-practices hardening pass.
