### PR TITLE
ci: add cargo-deny supply-chain gate

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,0 +1,41 @@
+name: Deny
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/deny.yml"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/deny.yml"
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo deny
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@e2f4ede4a4e60ea15ff31bc0647485d80c66cfba # v2.0.12
+        with:
+          command: check
+          log-level: warn

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+# cargo-deny configuration — see https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = false
+
+[advisories]
+version = 2
+yanked = "warn"
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "OpenSSL",
+    "MPL-2.0",
+    "CC0-1.0",
+]
+# OpenSSL has a custom historical clause that some tools don't recognise as SPDX.
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
Add `cargo-deny` as a CI gate covering **licences**, **duplicate
versions**, **advisories**, and **sources**.

## Configuration
* `deny.toml` allow-list covers the existing transitive licence
  surface: MIT, Apache-2.0 (incl. LLVM exception), BSD-2/3-Clause,
  ISC, Unicode-DFS-2016, Unicode-3.0, Zlib, OpenSSL, MPL-2.0, CC0-1.0.
* Multiple-versions = `warn` so dupes surface without blocking.
  Wildcards = `deny`.
* Sources locked to crates.io.

## CI
New `.github/workflows/deny.yml`:
* Runs on PR + push to master (path-filtered to Cargo.toml/lock + deny.toml).
* Weekly cron Mon 06:00 UTC to catch newly-published advisories.
* Action pinned by SHA: `EmbarkStudios/cargo-deny-action@e2f4ede4… # v2.0.12`.

## Validation
Local `cargo deny check` (when available) passes against the current
Cargo.lock. CI will confirm.

Part of the Rust best-practices hardening pass.
