### PR TITLE
chore(lints): forbid unsafe + deny pedantic/nursery via Cargo.toml lints table

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,3 +33,8 @@ jobs:
 
       - name: cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: cargo doc (rustdoc lints)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,20 @@ lto = "fat"
 codegen-units = 1
 strip = true
 panic = "abort"
+
+[lints.rust]
+unsafe_code      = "forbid"
+missing_docs     = "deny"
+unreachable_pub  = "deny"
+rust_2018_idioms = { level = "deny", priority = -1 }
+
+[lints.clippy]
+all      = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+nursery  = { level = "deny", priority = -1 }
+# Idiomatic in this crate: types like `httpbandwidthspeedtester::Speed`
+# inside the `httpbandwidthspeedtester` crate are unavoidable here.
+module_name_repetitions = "allow"
+# h2/hyper/idna routinely ship multiple versions transitively;
+# tracked by cargo-deny separately.
+multiple_crate_versions = "allow"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,18 @@
 /// bytes-per-second figure using 1024-based (binary) division.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Speed {
+    /// Bytes per second (the raw figure passed to [`Speed::from_bps`]).
     pub bps: u64,
+    /// Kibibytes per second (`bps / 1024`, rounded down).
     pub kib_s: u64,
+    /// Mebibytes per second (`bps / 1024 / 1024`, rounded down).
     pub mib_s: u64,
 }
 
 impl Speed {
     /// Format `bytes_per_sec` into B/s, KiB/s, and MiB/s.
-    pub fn from_bps(bytes_per_sec: u64) -> Self {
+    #[must_use]
+    pub const fn from_bps(bytes_per_sec: u64) -> Self {
         Self {
             bps: bytes_per_sec,
             kib_s: bytes_per_sec / 1024,
@@ -40,6 +44,7 @@ impl Speed {
 ///
 /// `cpu_count` is clamped to at least 1 to avoid divide-by-zero and to match
 /// the binary's runtime behaviour for single-CPU systems.
+#[must_use]
 pub fn compute_ranges(content_length: Option<u64>, cpu_count: u64) -> Vec<Option<String>> {
     let cpu_count = cpu_count.max(1);
     match content_length {
@@ -53,7 +58,7 @@ pub fn compute_ranges(content_length: Option<u64>, cpu_count: u64) -> Vec<Option
                     } else {
                         format!("{}", (i + 1) * bytes_per_cpu - 1)
                     };
-                    Some(format!("bytes={}-{}", start, end))
+                    Some(format!("bytes={start}-{end}"))
                 })
                 .collect()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+//! Binary entrypoint for the HTTP bandwidth speed-tester.
+//!
+//! Wires up the helpers in the sibling library crate
+//! (`httpbandwidthspeedtester::lib`) to a hyper-based HTTPS client, a
+//! per-second `print_loop`, and a fan-out of range-aware workers. Run
+//! with `httpbandwidthspeedtester <URL>`; see `--help` for details.
+
 use bytes::Bytes;
 use chrono::Local;
 use clap::Parser;
@@ -22,19 +29,27 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+/// Per-second and lifetime byte counters shared between workers and the
+/// `print_loop`. Lock-free: every operation is a relaxed atomic.
 struct Counters {
+    /// Bytes accumulated during the in-progress one-second window.
+    /// Reset by `print_loop` via [`Counters::take_bucket`].
     bytes_current_bucket: AtomicU64,
+    /// Total bytes downloaded across all workers since startup.
     total_bytes_downloaded: AtomicU64,
 }
 
 impl Counters {
-    fn new() -> Self {
+    /// Construct a fresh set of zeroed counters.
+    const fn new() -> Self {
         Self {
             bytes_current_bucket: AtomicU64::new(0),
             total_bytes_downloaded: AtomicU64::new(0),
         }
     }
 
+    /// Add `bytes` to both the current-second bucket and the lifetime
+    /// total. Called once per body chunk from each worker.
     fn record(&self, bytes: u64) {
         self.bytes_current_bucket
             .fetch_add(bytes, Ordering::Relaxed);
@@ -42,10 +57,13 @@ impl Counters {
             .fetch_add(bytes, Ordering::Relaxed);
     }
 
+    /// Atomically read the current-second bucket and zero it. Called
+    /// once per second by `print_loop`.
     fn take_bucket(&self) -> u64 {
         self.bytes_current_bucket.swap(0, Ordering::Relaxed)
     }
 
+    /// Snapshot of the lifetime total bytes downloaded.
     fn total(&self) -> u64 {
         self.total_bytes_downloaded.load(Ordering::Relaxed)
     }
@@ -149,7 +167,7 @@ struct Cli {
 fn parse_http_uri(s: &str) -> Result<Uri, String> {
     let uri: Uri = s.parse().map_err(|e| format!("invalid URL: {e}"))?;
     match uri.scheme_str() {
-        Some("http") | Some("https") => Ok(uri),
+        Some("http" | "https") => Ok(uri),
         Some(other) => Err(format!(
             "unsupported URL scheme `{other}://`; expected http:// or https://"
         )),
@@ -192,16 +210,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let accepts_ranges: bool = headers
         .get(ACCEPT_RANGES)
         .and_then(|v| v.to_str().ok())
-        .map(|v| {
+        .is_some_and(|v| {
             v.split(',')
                 .any(|tok| tok.trim().eq_ignore_ascii_case("bytes"))
-        })
-        .unwrap_or(false);
+        });
 
     // Calculate the number of bytes to download in each thread
-    let cpu_count: u64 = std::thread::available_parallelism()
-        .map(NonZeroUsize::get)
-        .unwrap_or(1) as u64;
+    let cpu_count: u64 = std::thread::available_parallelism().map_or(1, NonZeroUsize::get) as u64;
 
     let ranges: Vec<Option<String>> = match content_length {
         Some(cl) if cl > 0 && accepts_ranges => compute_ranges(Some(cl), cpu_count),
@@ -248,6 +263,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Print out the total bytes downloaded and the average speed
     let total_bytes = counters.total();
     let elapsed_secs = start_time.elapsed().as_secs_f64().max(1e-9);
+    // The cast triplet (u64 → f64 → u64) is a pragmatic choice for a
+    // human-readable B/s figure: for byte counts up to ~9 PB the f64
+    // mantissa carries enough precision, and the final value is
+    // guaranteed non-negative and bounded by `total_bytes`, so neither
+    // sign loss nor truncation is observable in practice.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss
+    )]
     let avg_speed: u64 = (total_bytes as f64 / elapsed_secs) as u64;
     let speed = Speed::from_bps(avg_speed);
     println!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,28 +1,24 @@
 // SPDX-License-Identifier: MIT
-//
-// End-to-end integration tests that spin up a mock HTTP server with
-// `wiremock` and shell out to the release binary so the assertions cover the
-// whole code path including argv parsing, the HEAD probe, the per-worker
-// range fan-out, and the final summary line.
-//
-// Scenarios covered:
-//   * `serves_file_with_content_length`         — happy path, exact byte count
-//   * `serves_file_without_content_length`      — B1 regression: chunked /
-//                                                 streaming fallback, *not* a
-//                                                 fan-out that downloads
-//                                                 N × file_size bytes
-//   * `non_success_status_exits_non_zero`        — B2 regression: a 404 must
-//                                                 fail the binary
-//   * `accept_ranges_none_still_succeeds`        — B5 regression: a server
-//                                                 that advertises
-//                                                 `Accept-Ranges: none` must
-//                                                 fall back to a single
-//                                                 worker and report exactly
-//                                                 `file_size` bytes — never
-//                                                 `cpu_count * file_size`.
-//   * `slow_server_completes`                    — sanity: a server that
-//                                                 trickles bytes still
-//                                                 finishes correctly
+
+//! End-to-end integration tests that spin up a mock HTTP server with
+//! `wiremock` and shell out to the release binary so the assertions
+//! cover the whole code path including argv parsing, the HEAD probe,
+//! the per-worker range fan-out, and the final summary line.
+//!
+//! Scenarios covered:
+//!
+//! * `serves_file_with_content_length` — happy path, exact byte count.
+//! * `serves_file_without_content_length` — B1 regression: chunked /
+//!   streaming fallback, *not* a fan-out that downloads
+//!   `N × file_size` bytes.
+//! * `non_success_status_exits_non_zero` — B2 regression: a 404 must
+//!   fail the binary.
+//! * `accept_ranges_none_still_succeeds` — B5 regression: a server
+//!   that advertises `Accept-Ranges: none` must fall back to a single
+//!   worker and report exactly `file_size` bytes — never
+//!   `cpu_count × file_size`.
+//! * `slow_server_completes` — sanity: a server that trickles bytes
+//!   still finishes correctly.
 
 use std::process::Stdio;
 use std::time::Duration;
@@ -34,12 +30,12 @@ use wiremock::{Mock, MockServer, Respond, ResponseTemplate};
 
 /// Path to the binary under test. Cargo sets `CARGO_BIN_EXE_<name>` when
 /// running integration tests, so this is rebuilt and located automatically.
-fn bin_path() -> &'static str {
+const fn bin_path() -> &'static str {
     env!("CARGO_BIN_EXE_httpbandwidthspeedtester")
 }
 
 /// Run the binary against `url` with a generous wall-clock timeout and return
-/// (exit_code, stdout, stderr).
+/// (`exit_code`, `stdout`, `stderr`).
 async fn run_binary(url: &str) -> (i32, String, String) {
     let mut child = Command::new(bin_path())
         .arg(url)
@@ -277,7 +273,9 @@ impl Respond for RangeResponder {
         let end: usize = if end_s.is_empty() {
             self.body.len().saturating_sub(1)
         } else {
-            end_s.parse().unwrap_or(self.body.len().saturating_sub(1))
+            end_s
+                .parse()
+                .unwrap_or_else(|_| self.body.len().saturating_sub(1))
         };
         let end = end.min(self.body.len().saturating_sub(1));
         let slice = if start > end {


### PR DESCRIPTION
## Summary

Add a workspace-level `[lints]` table to `Cargo.toml` so every target
(lib, bin, tests) inherits the same strict floor without `#![…]`
attributes scattered across source files. Forbid `unsafe`, deny
`pedantic` + `nursery` + idiomatic lints, and fix every resulting hit.

## Lint config

```toml
[lints.rust]
unsafe_code      = "forbid"
missing_docs     = "deny"
unreachable_pub  = "deny"
rust_2018_idioms = { level = "deny", priority = -1 }

[lints.clippy]
all      = { level = "deny", priority = -1 }
pedantic = { level = "deny", priority = -1 }
nursery  = { level = "deny", priority = -1 }
module_name_repetitions = "allow"   # type path inside its own crate
multiple_crate_versions = "allow"   # tracked by cargo-deny instead
```

`forbid(unsafe_code)` is intentionally stronger than `deny` — no
in-source `#[allow(unsafe_code)]` is possible without a `Cargo.toml`
edit, which is exactly the audit trail we want for any future
exception.

## Code fixes for the resulting lint hits

* `Speed::from_bps` → `const fn` + `#[must_use]`; struct field docs.
* `compute_ranges` → `#[must_use]`; inline `{start}-{end}` format args.
* `Counters::new` → `const fn`; struct fields + every method documented.
* `parse_http_uri` → nested or-pattern `Some("http" | "https")`.
* `Accept-Ranges` parsing uses `Option::is_some_and(…)` instead of
  `map(…).unwrap_or(false)`.
* The avg-speed cast triplet `u64 → f64 → u64` carries one targeted
  `#[allow(cast_precision_loss, cast_possible_truncation, cast_sign_loss)]`
  with a comment explaining why it's safe for the human-readable B/s
  figure (bytes ≤ 9 PB, sign always positive, output bounded).
* Crate-level `//!` docs on `main.rs`, `lib.rs`, and
  `tests/integration.rs`.
* `bin_path` in tests → `const fn`.
* `RangeResponder` fallback uses `unwrap_or_else(|_| …)` to drop the
  eager allocation flagged by `clippy::or_fun_call`.

## CI

The Lint workflow now also runs

```yaml
- name: cargo doc (rustdoc lints)
  env:
    RUSTDOCFLAGS: "-D warnings"
  run: cargo doc --no-deps --all-features
```

so broken intra-doc links fail CI alongside clippy.

## Validation

* `cargo fmt --check` ✅
* `cargo clippy --all-targets --all-features -- -D warnings` ✅ (0 lints)
* `cargo test --offline --no-fail-fast` ✅ (15/15)
* `cargo doc --no-deps -D warnings` ✅

Part of the Rust best-practices hardening pass.
