### PR TITLE
chore(meta): fill in Cargo.toml package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,13 @@ version = "0.1.0"
 authors = ["richardsondev"]
 edition = "2021"
 rust-version = "1.86"
+description = "Measure HTTP/HTTPS download bandwidth with parallel range requests"
+license = "MIT"
+repository = "https://github.com/richardsondev/httpbandwidthspeedtester"
+homepage = "https://github.com/richardsondev/httpbandwidthspeedtester"
+readme = "README.md"
+keywords = ["http", "download", "bandwidth", "speedtest", "cli"]
+categories = ["command-line-utilities", "network-programming"]
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
## Summary
Fill in the standard `[package]` metadata fields in `Cargo.toml` so the
crate carries identity information independent of being published:

* `description`
* `license = "MIT"` (matches `LICENSE`)
* `repository`, `homepage`
* `readme = "README.md"`
* `keywords` (≤5 entries, ≤20 chars each — crates.io limits)
* `categories` (`command-line-utilities`, `network-programming`)

## Validation
* `cargo build` — green.
* `cargo fmt --all --check` — clean.
* `cargo publish --dry-run --allow-dirty` — passes the metadata check (network may be flaky in CI; rely on the metadata lint in cargo itself).

Part of the Rust best-practices hardening pass.
