### PR TITLE
chore(deps): remove unused tokio-util and tokio-native-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,8 +506,6 @@ dependencies = [
  "hyper-util",
  "openssl",
  "tokio",
- "tokio-native-tls",
- "tokio-util",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,7 @@ hyper-util = { version = "0.1", features = ["client-legacy", "http1", "http2", "
 http-body-util = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "net"] }
 bytes = "1.11"
-tokio-util = { version = "0.7", features = ["codec"] }
 chrono = "0.4"
-tokio-native-tls = "0.3"
 futures-util = "0.3"
 openssl = { version = "0.10.79", features = ["vendored"] }
 


### PR DESCRIPTION
## Summary
Remove two unused dependencies from `Cargo.toml`:
* `tokio-util` (codec feature) — zero references in `src/` or `tests/`.
* `tokio-native-tls` — redundant alongside `hyper-tls`, also zero references.

## Why
Smaller dependency graph → fewer crates to keep updated, smaller
`cargo audit` and `cargo deny` surface, faster cold builds.

## Validation
* `cargo build` — green, `Cargo.lock` regenerated.
* `cargo clippy --all-targets --all-features -- -D warnings` — clean.
* `cargo test --offline --no-fail-fast` — 15/15.

Part of the Rust best-practices hardening pass.
