### PR TITLE
build: bump pinned Rust toolchain from 1.85.0 to 1.93.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "httpbandwidthspeedtester"
 version = "0.1.0"
 authors = ["richardsondev"]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.86"
 
 [lib]
 path = "src/lib.rs"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,6 +2,6 @@
 # the same compiler. Bumped via PR alongside any MSRV bump in
 # Cargo.toml.
 [toolchain]
-channel    = "1.85.0"
+channel    = "1.93.0"
 components = ["rustfmt", "clippy"]
 profile    = "minimal"


### PR DESCRIPTION
## Summary

Hotfix: bump the pinned Rust toolchain from `1.85.0` to `1.93.0`.

PR #110 pinned to `1.85.0`, which is below the floor required by current
transitive dependencies. After the merge the `Lint` workflow on `master`
started failing with:

```
error: rustc 1.85.0 is not supported by the following packages:
  icu_collections@2.2.0 requires rustc 1.86
  icu_normalizer@2.2.0 requires rustc 1.86
  icu_properties@2.2.0 requires rustc 1.86
  idna_adapter@1.2.2  requires rustc 1.86
  ...
```

The Cargo.lock baked in `idna@1.1.0` (via reqwest → hyper → url) which
in turn pulls `icu_*@2.2.0`, all of which set MSRV = 1.86.

## Changes

* `rust-toolchain.toml`: `channel = "1.85.0"` → `"1.93.0"` (stable as
  of 2026-01-22, matches the version the maintainer's workstation
  currently runs).
* `Cargo.toml`: `rust-version = "1.74"` → `"1.86"` to honestly reflect
  the floor imposed by the locked transitive deps.

## Validation

* `cargo --version` → `1.93.0`
* `cargo check --locked` — green
* No source changes; no behavioural impact.

Fixes the `Lint` workflow regression on `master` introduced by #110.
