### PR TITLE
docs: internal API docs + impl Default for Counters

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,19 +59,25 @@ impl Counters {
 
     /// Atomically read the current-second bucket and zero it. Called
     /// once per second by `print_loop`.
+    #[must_use]
     fn take_bucket(&self) -> u64 {
         self.bytes_current_bucket.swap(0, Ordering::Relaxed)
     }
 
     /// Snapshot of the lifetime total bytes downloaded.
+    #[must_use]
     fn total(&self) -> u64 {
         self.total_bytes_downloaded.load(Ordering::Relaxed)
     }
 }
 
-/*
-Download a range of bytes from the file
-*/
+impl Default for Counters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Download a range of bytes from the file
 async fn start_download(
     client: Arc<Client<HttpsConnector<HttpConnector>, Empty<Bytes>>>,
     url: Uri,
@@ -104,9 +110,7 @@ async fn start_download(
     Ok(())
 }
 
-/*
-Print the download speed every second
-*/
+/// Print the download speed every second
 async fn print_loop(counters: Arc<Counters>) {
     let mut past_seconds: VecDeque<u64> = VecDeque::with_capacity(10);
 


### PR DESCRIPTION
## Summary
Round out internal API documentation on top of the `[lints]` table introduced by #112:

* Convert the `/* … */` block comments above `start_download` and `print_loop` into `///` doc comments so they show up in `cargo doc`.
* Add `impl Default for Counters { fn default() -> Self { Self::new() } }`.
* Mark `Counters::take_bucket` and `Counters::total` as `#[must_use]` for consistency with the public-API `#[must_use]` style.

## Validation
* `cargo fmt --all --check` — clean
* `cargo clippy --all-targets --all-features -- -D warnings` — clean
* `cargo test --no-fail-fast` — 15/15
* `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` — clean

No behaviour change.
